### PR TITLE
Fix query by example

### DIFF
--- a/ferelight/__init__.py
+++ b/ferelight/__init__.py
@@ -2,4 +2,4 @@
 FERElight - Extremely lightweight and purpose-built feature extraction and retrieval engine (FERE).
 """
 
-__version__ = "1.0.4"
+__version__ = "1.0.5"

--- a/ferelight/controllers/default_controller.py
+++ b/ferelight/controllers/default_controller.py
@@ -232,7 +232,8 @@ def querybyexample_post(body):  # noqa: E501
         limit = f'LIMIT {body["limit"]}' if 'limit' in body else ''
 
         if 'limit' in body:
-            cur.execute('SET hnsw.ef_search = %s', (body['limit'],))
+            # +1 to limit to include the segment itself which limit will remove
+            cur.execute('SET hnsw.ef_search = %s', (body['limit'] + 1,))
 
         cur.execute(
             f"""


### PR DESCRIPTION
Fixes the query by example endpoint returning limit - 1 results.

Due to the index being configured only to return limit results, but the first result (the example segment) being removed in the SQL query, the endpoint always returned a maximum of limit - 1 results.

Fixed by increasing the index limit by 1.